### PR TITLE
made `check_hardness` check if block's unbreakable

### DIFF
--- a/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectMineRadius.kt
+++ b/eco-api/src/main/kotlin/com/willfp/libreforge/effects/effects/EffectMineRadius.kt
@@ -61,7 +61,7 @@ class EffectMineRadius : Effect(
                     }
 
                     if (config.getBool("check_hardness")) {
-                        if (toBreak.type.hardness > block.type.hardness) {
+                        if (toBreak.type.hardness == -1 || toBreak.type.hardness > block.type.hardness) {
                             continue
                         }
                     }


### PR DESCRIPTION
`mine_radius` during `check_hardness` was ignoring whether the block was unbreakable or not. Adjusted it just by checking if type hardness is -1

https://github.com/Auxilor/EcoEnchants/issues/324